### PR TITLE
Add .env.example to linguist detectable ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.env.example -linguist-detectable


### PR DESCRIPTION
Earlier `.env.example` file was causing issues with GitHub language bar.