### PR TITLE
New subcommand for github.ts: org

### DIFF
--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -41,7 +41,7 @@ export default function(message: Discord.Message) {
 		fetch(url+'/users/'+argument.match(/[A-Za-z1-9\-]+$/)) 
 		.then(response=>{
 				if (response.status !== 200) {
-					message.channel.send('GitHub user not found. If you looks to search for a organization try running `-gh org <organization username`');
+					message.channel.send('GitHub user not found.');
 					return;
 				}
 				response.json().then(function(data) {
@@ -67,13 +67,13 @@ export default function(message: Discord.Message) {
 	}
 	else if(argument.match(/^org/i)){
 		if(!argument.match(/^org[\s]+[A-Za-z0-9\-]+$/)){
-			message.channel.send("No username provided or more than 1 username provided. BotRanger can only send GitHub user data once at a time");
+			message.channel.send("No username provided or more than 1 username provided. BotRanger can handle only 1 GitHub user at a time");
 			return;
 		}
 		fetch(url+'/orgs/'+argument.match(/[A-Za-z1-9\-]+$/)) 
 		.then(response=>{
 				if (response.status !== 200) {
-					message.channel.send('GitHub organization not found. If you looks to search for a organization try running `-gh org <organization username`');
+					message.channel.send('GitHub organization not found. If you are searching for a user try running `-gh user <username>`');
 					return;
 				}
 				response.json().then(function(data) {

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -64,6 +64,36 @@ export default function(message: Discord.Message) {
 			message.channel.send('Fetch Error :-S', err);
 		});
 	}
+	else if(argument.match(/^org/i)){
+		if(!argument.match(/^org[\s]+[A-Za-z0-9\-]+$/)){
+			message.channel.send("No username provided or more than 1 username provided. BotRanger can only send GitHub user data once at a time");
+			return;
+		}
+		fetch(url+'/orgs/'+argument.match(/[A-Za-z1-9\-]+$/)) 
+		.then(response=>{
+				if (response.status !== 200) {
+					message.channel.send('GitHub organization not found. If you looks to search for a organization try running `-gh org <organization username`');
+					return;
+				}
+				response.json().then(function(data) {
+					let msg = new Discord.MessageEmbed()
+						.setColor('#304f55')
+						.setTitle(data.name)
+						.setURL(data.html_url)
+						.addFields(
+							{ name: 'Username', value: data.login, inline: true },
+							{ name: 'Verified', value: data.is_verified ? 'Yes' : 'No', inline: true },
+						)
+						.setThumbnail(data.avatar_url)
+						.setTimestamp()
+					message.channel.send(msg);
+				});
+			}
+		)
+		.catch(function(err) {
+			message.channel.send('Fetch Error :-S', err);
+		});
+	}
 	else if(argument.match(/^repo/i)){
 		if(!argument.match(/^repo[\s]+[A-Za-z1-9\-]+[\/][A-Za-z1-9\-]+$/))
 			message.channel.send("Repository should be in the form `<username/repo>`")

--- a/src/commands/github.ts
+++ b/src/commands/github.ts
@@ -53,6 +53,7 @@ export default function(message: Discord.Message) {
 							{ name: 'Username', value: data.login, inline: true },
 							{ name: 'Followers', value: data.followers, inline: true },
 							{ name: 'Following', value: data.following, inline: true },
+							{ name: 'Account Type', value: data.type, inline: true }
 						)
 						.setThumbnail(data.avatar_url)
 						.setTimestamp()


### PR DESCRIPTION
The new subcommand for github command is similiar to `-gh user`.

`gh user <organization-username>` returns similiar data as to `gh org <organization-username>` except it returns followers and following count as 0. Call this a bug in API or made to work this way.

Also using `gh user` for fetching organization data doesn't say whether the organisation is verified or not, but says whether the user is User or Organisation.