### PR TITLE
Removed invite link for BotRanger

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ A Discord bot for your awesome server
 
 `-help` to see complete help message in Discord.
 
-[Click here to invite **BotRanger**](https://discord.com/oauth2/authorize?client_id=769436540329394189&scope=bot&permissions=8)
+


### PR DESCRIPTION
This PR

<!-- 
    Mark all that apply
-->
- [ ] adds/removes a new command
- [ ] Fixes bug(s) in any of the already defined command
- [ ] includes adding/removing dependencies
- [ ] includes changes in CI Pipelines
- [ ] Documentation changes


From 15 Feb 2021 12:00 PM IST, BotRanger will become a private bot. So the invite link won't work


<!--

Uncomment this section if this contains any dependency changes

New dependencies added:
- `<dependency 1>`
- `<dependency 2>`
- `...`

Dependencies removed:
- `<dependency 1>`
- `<dependency 2>`
- `...`

Dependencies updated:
- `<dependency 1>` from `<current version>` to `<new version>`
- `<dependency 2>` from `<current version>` to `<new version>`
- `...`

-->

